### PR TITLE
Allow form parameters to be passed by URL

### DIFF
--- a/display-text-changes-from-timemap.ipynb
+++ b/display-text-changes-from-timemap.ipynb
@@ -20,9 +20,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "# Parameters:\n",
+    "archive = \"\"\n",
+    "url = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>.diff_add {background-color: #ccffcc;} .diff_chg {background-color: #ffffcc; text-decoration: underline;} .diff_sub {background-color: #ffcccc; text-decoration: line-through;} table.diff, table.diff thead {border: 1px solid black;} table.diff {table-layout: fixed; width: 100%; margin-bottom: 20px;} th.diff_next, td.diff_next {width: 4%;} table.diff th.diff_header {text-align: left;} table.diff tbody {border: none;} table.diff td {word-break: break-word; text-align: left;}</style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from difflib import HtmlDiff\n",
     "import requests\n",
@@ -40,9 +65,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "// This is necessary in Jupyter notebook to stop the output area folding up\n",
+       "// Will give an error in Jupyter Lab\n",
+       "IPython.OutputArea.prototype._should_scroll = function(lines) {return false}\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%javascript\n",
     "// This is necessary in Jupyter notebook to stop the output area folding up\n",
@@ -52,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,9 +107,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "71d7bf848ade42de88b0e6eba7fb7209",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Dropdown(description='Archive:', options=(('---', ''), ('UK Web Archive', 'bl'), ('National Lib…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0c7fe9c1142949528ba361b155483fdc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Button(button_style='primary', description='Show text changes', style=ButtonStyle()), Button(de…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1a77fdd0c70c41748c5236490e4397d8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# This deque will only hold a maximum of two values\n",
     "# So we can just push new pages into it, and it will shove the old ones out the back.\n",
@@ -226,9 +309,10 @@
     "    options=[('---', ''), ('UK Web Archive', 'bl'), ('National Library of Australia', 'nla'), ('National Library of New Zealand', 'nlnz'), ('Internet Archive', 'ia')],\n",
     "    description='Archive:',\n",
     "    disabled=False,\n",
+    "    value=archive\n",
     ")\n",
     "\n",
-    "target_url = widgets.Text(description='URL:')\n",
+    "target_url = widgets.Text(description='URL:', value=url)\n",
     "\n",
     "tc_button = widgets.Button(description='Show text changes', button_style='primary')\n",
     "tc_button.on_click(start)\n",
@@ -248,6 +332,13 @@
     "\n",
     "Work on this notebook was supported by the [IIPC Discretionary Funding Programme 2019-2020](http://netpreserve.org/projects/)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/postBuild
+++ b/postBuild
@@ -3,4 +3,7 @@
 jupyter nbextension     enable --py --sys-prefix appmode
 jupyter serverextension enable --py --sys-prefix appmode
 
+jupyter nbextension install --py jupyter_notebookparams --sys-prefix
+jupyter nbextension enable --py jupyter_notebookparams --sys-prefix
+
 sed -i 's/\#!\/srv\/conda\/envs\/notebook\/bin\/python/\#!\/usr\/bin\/python3/'  /srv/conda/envs/notebook/bin/unoconv

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ jupyter==1.0.0
 jupyter-client==6.1.3
 jupyter-console==6.1.0
 jupyter-core==4.6.3
+jupyter-notebookparams==0.0.4
 jupyterlab==2.1.2
 jupyterlab-server==1.1.1
 jusText==2.2.0


### PR DESCRIPTION
This pull requests adds the [jupyter-notebookparams](https://github.com/manics/jupyter-notebookparams) extension mentioned [here](https://discourse.jupyter.org/t/pass-parameters-to-a-notebook-on-jupyterhub-binderhub/1973/5) and modified the `display-text-changes-from-timemap` notebook to support passing parameters via the URL.

https://mybinder.org/v2/gh/ukwa/web-archives/anjackson-patch-1?urlpath=/apps/display-text-changes-from-timemap.ipynb%3Farchive="bl"%26url="https://www.gov.uk/government/publications/coronavirus-action-plan/coronavirus-action-plan-a-guide-to-what-you-can-expect-across-the-uk"%26autorun=true

(Note super-hacky additional encoding of `?` and `&` to get them passed through)